### PR TITLE
performance(imu)!: use kernel edge timestamp for IMU samples

### DIFF
--- a/sensing/imu/types.py
+++ b/sensing/imu/types.py
@@ -8,7 +8,8 @@ class IMUData:
     """A single IMU sample with accelerometer and gyroscope readings.
 
     Attributes:
-        timestamp: CLOCK_REALTIME seconds captured at the DRDY interrupt edge.
+        timestamp_ns: CLOCK_REALTIME nanoseconds captured by the kernel at the
+            DRDY interrupt edge.
 
         accel_x: Acceleration along X-axis in m/s².
         accel_y: Acceleration along Y-axis in m/s².
@@ -27,7 +28,7 @@ class IMUData:
         0.001...
     """
 
-    timestamp: float
+    timestamp_ns: int
     accel_x: float
     accel_y: float
     accel_z: float


### PR DESCRIPTION
## Related Issue

Closes #30

## Context

Our system has a Stratum 1 NTP setup where `CLOCK_REALTIME` is disciplined to UTC with nanosecond precision via the GNSS (ZED-F9P) PPS signal and Chrony. The previous implementation captured IMU timestamps by calling `time.clock_gettime(CLOCK_REALTIME)` in Python user space after `wait_edge_events()` returned. OS context switching introduced tens to hundreds of microseconds of jitter between the physical DRDY edge and the recorded timestamp, wasting the precision of the hardware synchronization.

`libgpiod` records the exact moment of each GPIO edge inside the kernel. By setting `event_clock=Clock.REALTIME` in `LineSettings`, the kernel timestamps each edge using `CLOCK_REALTIME` at the instant it fires. The raw integer nanosecond value is passed directly into `IMUData`, avoiding the ~350 ns precision loss that a `float` conversion would introduce.

## Changes

- `sensing/imu/types.py`: Replace `timestamp: float` with `timestamp_ns: int`; update docstring
- `sensing/imu/reader.py`: Add `Clock` import; set `event_clock=Clock.REALTIME` in `LineSettings`; extract `events[0].timestamp_ns` in `read()` instead of calling `time.clock_gettime`; update `_parse_sample` / `_read_sample` signatures and docstrings
- `tests/imu/test_reader.py`: Replace `clock_gettime` mock with a mock edge event carrying `timestamp_ns`; update all call sites; add `Clock.REALTIME` assertion to GPIO setup test; rename timestamp test to `test_timestamp_comes_from_kernel_edge_event`

## Type of Change

- [x] Breaking change (existing functionality will not work as expected)
- [x] Performance improvement
- [x] Test addition or update

## Test Steps

1. `uv run --extra dev pytest tests/imu/ -q` — all 44 tests should pass
2. `uv run --extra dev ruff check sensing/imu/ tests/imu/` — no warnings
3. `uv run --extra dev mypy sensing/imu/ tests/imu/` — no new errors (3 pre-existing errors in `test_reader.py` unrelated to this change)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed

## Review Focus (optional)

- `reader.py:244-246`: The new `read()` body — confirm `events[0]` is safe to index after `wait_edge_events()` returns `True`
- `types.py:30`: The `timestamp_ns: int` field — confirm downstream callers have been updated