### PR TITLE
fix(server): eliminate cross-thread subscriber list access in broadcast

### DIFF
--- a/server/broadcaster.py
+++ b/server/broadcaster.py
@@ -23,7 +23,11 @@ def _enqueue_message(queue: asyncio.Queue[str], message: str) -> None:
     queue.put_nowait(message)
 
 
+def _broadcast_all(message: str) -> None:
+    for queue in list(_subscriber_queues):
+        _enqueue_message(queue, message)
+
+
 def broadcast_message(message: str, loop: asyncio.AbstractEventLoop) -> None:
     """Dispatch a message to all active subscriber queues safely."""
-    for queue in list(_subscriber_queues):
-        loop.call_soon_threadsafe(_enqueue_message, queue, message)
+    loop.call_soon_threadsafe(_broadcast_all, message)


### PR DESCRIPTION
## Related Issue

Closes #43

## Context

`broadcast_message()` was called from sensor background threads and iterated `list(_subscriber_queues)` to snapshot the current subscribers. Concurrently, `websocket_endpoint()` on the event-loop thread called `append`/`remove` on the same list. With CPython's GIL this is safe in practice, but it is a data race under the Python memory model and incorrect on free-threaded builds (CPython 3.13t+), which this project's `requires-python = ">=3.13"` makes a realistic concern.

## Changes

- Add `_broadcast_all(message)` — a private function that snapshots `_subscriber_queues` and calls `_enqueue_message` for each subscriber
- Change `broadcast_message` to schedule `_broadcast_all` onto the event-loop thread with a single `loop.call_soon_threadsafe` call instead of one call per subscriber

`_subscriber_queues` is now accessed exclusively from the event-loop thread, so no lock is needed and the race is eliminated by design (approach 2 from the issue).

## Type of Change

- [x] Bug fix (fixes an issue)

## Test Steps

1. `uv run --extra dev ruff check server/` — no errors
2. `uv run --extra dev mypy server/` — no issues
3. `uv run --extra dev --extra server pytest tests/ -q` — 108 passed

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors

## Review Focus (optional)

The key invariant after this change: every access to `_subscriber_queues` happens inside a `call_soon_threadsafe` callback, which the event loop serialises. No lock is required.