### PR TITLE
refactor(gnss): replace pyserial with gpsd client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "gpiod>=2.4.0",
-    "pyserial>=3.5",
     "spidev>=3.8",
 ]
 

--- a/sensing/gnss/reader.py
+++ b/sensing/gnss/reader.py
@@ -1,45 +1,126 @@
-"""GNSSReader: serial NMEA stream reader for u-blox ZED-F9P.
+"""GNSSReader: gpsd JSON client for GNSS data streaming.
 
-Hardware configuration:
-    UART5 on Raspberry Pi 4B → /dev/ttyAMA5 at 38400 bps
-    u-blox ZED-F9P outputs GGA + VTG sentences at approximately 1 Hz.
+Connects to a local gpsd instance over TCP (localhost:2947) instead of
+opening the serial port directly. This allows the server to coexist with
+gpsd, which feeds NMEA sentences to Chrony via shared memory (SHM 0) for
+time synchronization.
 
 Reading strategy:
-    Lines are consumed one at a time. VTG sentences update internal state.
-    GGA sentences trigger a ``GNSSData`` yield containing the GGA data paired
-    with the most recently received VTG. All other sentence types are silently
-    skipped. Sentences that fail checksum validation are also discarded.
+    gpsd emits newline-delimited JSON on its client socket. TPV messages
+    supply position, fix quality, speed, and track. SKY messages supply
+    satellite count and HDOP. On each TPV event the most recently received
+    SKY fields are merged to produce a GNSSData, mirroring the GGA+VTG
+    pairing of the former serial reader.
 """
 
+import contextlib
+import json
+import socket
 from collections.abc import Iterator
+from io import BufferedReader
 from types import TracebackType
-from typing import TYPE_CHECKING
-
-import serial  # type: ignore[import-untyped]
+from typing import Any
 
 from sensing.gnss.types import GNSSData
-from sensing.nmea.gga import parse_gga
-from sensing.nmea.vtg import parse_vtg
+from sensing.nmea.types import GGAData, VTGData
 
-if TYPE_CHECKING:
-    from sensing.nmea.types import VTGData
+__all__ = ["GNSSReader"]
 
-# --- Hardware defaults -------------------------------------------------------
+# --- gpsd connection defaults -------------------------------------------------
 
-_PORT = "/dev/ttyAMA5"
-_BAUDRATE = 38400
-_TIMEOUT = 2.0  # seconds; enough for a full 1 Hz sentence cycle
+_HOST = "localhost"
+_PORT = 2947
+_TIMEOUT = 2.0  # socket read timeout; determines maximum cancel() latency
+
+_WATCH_CMD = b'?WATCH={"enable":true,"json":true}\n'
+
+# --- unit conversions ---------------------------------------------------------
+
+_MPS_TO_KNOTS = 1.94384
+_MPS_TO_KPH = 3.6
+
+# --- gpsd status codes --------------------------------------------------------
+
+# gpsd TPV.status -> NMEA GGA fix_quality
+# Source: https://gpsd.gitlab.io/gpsd/gpsd_json.html
+_STATUS_TO_FIX_QUALITY: dict[int, int] = {
+    0: 0,  # No fix    -> Invalid
+    1: 1,  # Normal    -> GPS fix (SPS)
+    2: 2,  # DGPS      -> DGPS fix
+    3: 4,  # RTK Fixed -> RTK Fixed
+    4: 5,  # RTK Float -> RTK Float
+    5: 6,  # DR        -> Dead reckoning
+}
+
+# gpsd TPV.status -> NMEA VTG FAA mode indicator
+_STATUS_TO_VTG_MODE: dict[int, str] = {
+    0: "N",  # No fix     -> Not valid
+    1: "A",  # Normal GPS -> Autonomous
+    2: "D",  # DGPS       -> Differential
+    3: "D",  # RTK Fixed  -> Differential
+    4: "D",  # RTK Float  -> Differential
+    5: "E",  # DR         -> Estimated
+}
 
 
-# --- Public API --------------------------------------------------------------
+# --- helpers ------------------------------------------------------------------
+
+
+def _count_used_from_sky(msg: dict[str, Any]) -> int | None:
+    """Return the number of satellites used in fix from a SKY message.
+
+    Precedence:
+
+    1. ``uSat`` - explicit used count (gpsd >= 3.19).
+    2. ``satellites[].used`` - derived from per-satellite flags when ``uSat``
+       is absent (older gpsd).
+    3. ``nSat`` - total satellites visible, used only as a last resort because
+       it counts satellites *in view*, not *in use*, and therefore
+       over-estimates the GGA field semantics.
+    """
+    u_sat: int | None = msg.get("uSat")
+    if u_sat is not None:
+        return u_sat
+    satellites = msg.get("satellites")
+    if isinstance(satellites, list):
+        has_flag = any("used" in s for s in satellites if isinstance(s, dict))
+        if has_flag:
+            return sum(1 for s in satellites if isinstance(s, dict) and s.get("used"))
+    n_sat = msg.get("nSat")
+    if isinstance(n_sat, int):
+        return n_sat
+    return None
+
+
+def _iso_to_utc_time(iso: str) -> str:
+    """Convert an ISO 8601 UTC timestamp to HHMMSS.ss format.
+
+    For example ``"2025-03-01T12:35:19.000Z"`` becomes ``"123519.00"``.
+    """
+    # "2025-03-01T12:35:19.000Z" -> slice off the time part after 'T'
+    t = iso[11:]  # "12:35:19.000Z"
+    hh = t[0:2]
+    mm = t[3:5]
+    ss_rest = t[6:].rstrip("Z")  # "19.000" or "19"
+    if "." in ss_rest:
+        ss, frac = ss_rest.split(".", 1)
+        return f"{hh}{mm}{ss}.{frac[:2].ljust(2, '0')}"
+    return f"{hh}{mm}{ss_rest}.00"
+
+
+# --- public API ---------------------------------------------------------------
 
 
 class GNSSReader:
-    """Context manager for reading GNSS data from a serial NMEA 0183 stream.
+    """Context manager for reading GNSS data from a gpsd JSON stream.
 
-    Manages the serial port for the lifetime of the ``with`` block. On entry
-    the port is opened; on exit it is closed regardless of exceptions. Two
-    consumption patterns are supported:
+    Connects to a local gpsd instance over TCP and consumes its
+    newline-delimited JSON stream. TPV messages provide position, fix
+    quality, speed, and track; SKY messages provide satellite count and
+    HDOP. On each TPV event the most recently received SKY fields are
+    merged with the TPV fields to produce a ``GNSSData``.
+
+    Two consumption patterns are supported:
 
     Continuous iteration (recommended for server backends)::
 
@@ -54,37 +135,53 @@ class GNSSReader:
 
     Each emitted ``GNSSData`` contains:
 
-    * ``gga`` — the freshly parsed GGA sentence (always present, may have
-      ``valid=False`` when there is no fix).
-    * ``vtg`` — the most recently received VTG sentence, or ``None`` until
-      the first VTG has been seen.
+    * ``gga`` - position, fix quality, satellite count, and HDOP assembled
+      from the TPV and the most recent SKY message. ``gga.valid`` is
+      ``False`` when gpsd reports no fix.
+    * ``vtg`` - velocity assembled from the same TPV message.
+      ``vtg.valid`` is ``False`` when there is no fix.
 
     Args:
-        port: Serial device path (default: ``/dev/ttyAMA5``).
-        baudrate: Baud rate matching the receiver configuration (default: 38400).
+        host: gpsd host (default: ``"localhost"``).
+        port: gpsd TCP port (default: ``2947``).
     """
 
     def __init__(
         self,
-        port: str = _PORT,
-        baudrate: int = _BAUDRATE,
+        host: str = _HOST,
+        port: int = _PORT,
     ) -> None:
-        """Store connection parameters; the port is opened in ``__enter__``."""
+        """Store connection parameters; the socket is opened in ``__enter__``."""
+        self._host = host
         self._port = port
-        self._baudrate = baudrate
-        self._serial: serial.Serial | None = None
-        self._last_vtg: VTGData | None = None
+        self._sock: socket.socket | None = None
+        self._stream: BufferedReader | None = None
         self._cancelled: bool = False
+        self._last_num_satellites: int | None = None
+        self._last_hdop: float | None = None
+
+    def _open_connection(self) -> tuple[socket.socket, BufferedReader]:
+        """Create and configure the gpsd TCP connection.
+
+        Closes the socket before re-raising if setup fails after the initial
+        ``create_connection`` call, preventing a file-descriptor leak.
+        """
+        sock = socket.create_connection((self._host, self._port))
+        try:
+            sock.settimeout(_TIMEOUT)
+            sock.sendall(_WATCH_CMD)
+            return sock, sock.makefile("rb")
+        except Exception:
+            with contextlib.suppress(OSError):
+                sock.close()
+            raise
 
     def __enter__(self) -> "GNSSReader":
-        """Open the serial port and reset internal VTG state."""
-        self._serial = serial.Serial(
-            self._port,
-            baudrate=self._baudrate,
-            timeout=_TIMEOUT,
-        )
-        self._last_vtg = None
+        """Open the gpsd connection and reset internal state."""
+        self._sock, self._stream = self._open_connection()
         self._cancelled = False
+        self._last_num_satellites = None
+        self._last_hdop = None
         return self
 
     def __exit__(
@@ -93,65 +190,159 @@ class GNSSReader:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Close the serial port."""
-        if self._serial is not None:
-            self._serial.close()
-            self._serial = None
-
-    def _process_line(self, line: str) -> GNSSData | None:
-        vtg = parse_vtg(line)
-        if vtg is not None:
-            self._last_vtg = vtg
-            return None
-        gga = parse_gga(line)
-        if gga is not None:
-            return GNSSData(gga=gga, vtg=self._last_vtg)
-        return None
+        """Close the gpsd connection."""
+        if self._stream is not None:
+            self._stream.close()
+            self._stream = None
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
 
     def cancel(self) -> None:
         """Cancel pending blocking reads gracefully.
 
-        Uses the underlying serial implementation to cancel I/O, allowing
-        background threads to exit cleanly without waiting for timeouts.
+        Sets the cancellation flag and shuts down the socket so that any
+        in-progress ``readline()`` unblocks immediately and raises
+        ``EOFError``, allowing background threads to exit without waiting
+        for the next timeout cycle.
         """
         self._cancelled = True
-        if self._serial is None:
-            return
-        self._serial.cancel_read()
+        if self._sock is not None:
+            with contextlib.suppress(OSError):
+                self._sock.shutdown(socket.SHUT_RDWR)
 
-    def _read_line(self, ser: "serial.Serial") -> str:
-        """Read one line from serial; empty string means serial timeout."""
-        line: str = ser.readline().decode("ascii", errors="ignore")
-        if not line and self._cancelled:
-            raise EOFError("Serial port read cancelled.")
-        return line
+    def _recv_raw(self, stream: BufferedReader) -> bytes | None:
+        """Read one raw line from gpsd; returns ``None`` on timeout retry.
+
+        ``TimeoutError`` (which is ``socket.timeout`` in Python 3.3+) is
+        caught before the generic ``OSError`` clause so that normal polling
+        gaps are silently retried rather than treated as fatal connection
+        errors.
+
+        Raises:
+            EOFError: If the stream ended or the connection was closed.
+        """
+        try:
+            raw: bytes = stream.readline()
+            if not raw:
+                raise EOFError("gpsd stream ended.")
+            return raw
+        except TimeoutError:
+            return None
+        except OSError as e:
+            raise EOFError("gpsd connection closed.") from e
+
+    def _read_line(self) -> str | None:
+        """Read and decode one JSON line; returns ``None`` on timeout retry.
+
+        Raises:
+            RuntimeError: If called outside a ``with`` block.
+            EOFError: If cancelled, or the stream ended or was closed.
+        """
+        if self._stream is None:
+            raise RuntimeError("GNSSReader must be used as a context manager.")
+        raw = self._recv_raw(self._stream)
+        if raw is None and self._cancelled:
+            raise EOFError("gpsd read cancelled.")
+        if raw is None:
+            return None
+        return raw.decode("utf-8", errors="ignore").strip()
+
+    def _process_sky(self, msg: dict[str, Any]) -> None:
+        """Update stored satellite count and HDOP from a SKY message."""
+        self._last_num_satellites = _count_used_from_sky(msg)
+        self._last_hdop = msg.get("hdop")
+
+    def _build_gga(
+        self,
+        msg: dict[str, Any],
+        fix_quality: int,
+        utc_time: str | None,
+    ) -> GGAData:
+        """Assemble a ``GGAData`` from TPV message fields and stored SKY state."""
+        # gpsd >= 3.25 renamed alt (MSL) to altMSL and added altHAE
+        alt: float | None = msg.get("altMSL")
+        if alt is None:
+            alt = msg.get("alt")
+        return GGAData(
+            utc_time=utc_time,
+            latitude_degrees=msg.get("lat"),
+            longitude_degrees=msg.get("lon"),
+            fix_quality=fix_quality,
+            num_satellites=self._last_num_satellites,
+            horizontal_dilution_of_precision=self._last_hdop,
+            altitude_meters=alt,
+            geoid_height_meters=None,
+            valid=fix_quality > 0,
+        )
+
+    def _build_vtg(self, msg: dict[str, Any], status: int) -> VTGData:
+        """Assemble a ``VTGData`` from TPV message fields."""
+        speed_mps: float | None = msg.get("speed")
+        track: float | None = msg.get("track")
+        vtg_mode = _STATUS_TO_VTG_MODE.get(status, "N")
+        kph = speed_mps * _MPS_TO_KPH if speed_mps is not None else None
+        return VTGData(
+            track_true_degrees=track,
+            speed_knots=speed_mps * _MPS_TO_KNOTS if speed_mps is not None else None,
+            speed_kilometers_per_hour=kph,
+            speed_meters_per_second=speed_mps,
+            mode=vtg_mode,
+            valid=vtg_mode != "N",
+        )
+
+    def _process_tpv(self, msg: dict[str, Any]) -> GNSSData:
+        """Assemble a ``GNSSData`` from a TPV message and stored SKY state."""
+        status: int = msg.get("status", 0)
+        fix_quality = _STATUS_TO_FIX_QUALITY.get(status, 0)
+        iso_time: str | None = msg.get("time")
+        utc_time = _iso_to_utc_time(iso_time) if iso_time else None
+        gga = self._build_gga(msg, fix_quality, utc_time)
+        vtg = self._build_vtg(msg, status)
+        return GNSSData(gga=gga, vtg=vtg)
+
+    def _dispatch(self, line: str) -> GNSSData | None:
+        """Parse one JSON line, update state, and return data on TPV."""
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        msg: dict[str, Any] = parsed
+        cls = msg.get("class")
+        if cls == "SKY":
+            self._process_sky(msg)
+        elif cls == "TPV":
+            return self._process_tpv(msg)
+        return None
 
     def read(self) -> GNSSData:
-        """Block until the next GGA sentence and return a combined GNSS sample.
+        """Block until the next TPV message and return a combined GNSS sample.
 
         Raises:
             RuntimeError: If called outside a ``with`` block.
             EOFError: If the read is cancelled or the stream ends.
         """
-        if self._serial is None:
+        if self._sock is None:
             raise RuntimeError("GNSSReader must be used as a context manager.")
         while True:
-            line = self._read_line(self._serial)
-            if not line:
+            line = self._read_line()
+            if line is None:
                 continue
-            result = self._process_line(line)
+            result = self._dispatch(line)
             if result is not None:
                 return result
 
     def __iter__(self) -> Iterator[GNSSData]:
-        """Yield GNSS samples indefinitely, one per GGA sentence.
+        """Yield GNSS samples indefinitely, one per TPV message.
 
         Iteration continues until the caller breaks the loop or an exception
-        propagates out (e.g. serial read error). ``StopIteration`` is never
-        raised.
+        propagates out (e.g. ``EOFError`` on cancellation). ``StopIteration``
+        is never raised.
 
         Yields:
-            ``GNSSData`` for each received GGA sentence.
+            ``GNSSData`` for each received TPV message.
         """
         while True:
             yield self.read()

--- a/tests/gnss/test_reader.py
+++ b/tests/gnss/test_reader.py
@@ -1,39 +1,108 @@
-"""Tests for the GNSS serial reader module."""
+"""Tests for the GNSS gpsd client reader module."""
 
+import contextlib
 import itertools
+import json
+import socket
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-import serial
 
 from sensing.gnss import GNSSData, GNSSReader
 from sensing.nmea.types import GGAData, VTGData
 
 # ---------------------------------------------------------------------------
-# Valid NMEA sentence constants
+# gpsd JSON message dictionaries
 # ---------------------------------------------------------------------------
 
-# RTK Fixed, 12 satellites — from sensing.nmea.types docstring
-_GGA_RTK = "$GNGGA,123519.00,4807.038,N,01131.000,E,4,12,0.5,545.4,M,47.0,M,,*7D"
+# RTK Fixed fix, with speed and track
+_TPV_RTK = {
+    "class": "TPV",
+    "status": 3,
+    "time": "2025-03-01T12:35:19.000Z",
+    "lat": 48.1173,
+    "lon": 11.5167,
+    "altMSL": 545.4,
+    "speed": 2.833,
+    "track": 54.7,
+}
 
 # Standard GPS fix
-_GGA_SPS = "$GNGGA,123519.00,4807.038,N,01131.000,E,1,08,0.9,545.4,M,47.0,M,,*7F"
+_TPV_SPS = {
+    "class": "TPV",
+    "status": 1,
+    "time": "2025-03-01T12:35:19.000Z",
+    "lat": 48.1173,
+    "lon": 11.5167,
+    "altMSL": 545.4,
+    "speed": 2.833,
+    "track": 54.7,
+}
 
-# No fix (fix_quality=0)
-_GGA_NO_FIX = "$GNGGA,123519.00,,,,,,0,00,99.9,,M,,M,,*60"
+# DGPS fix
+_TPV_DGPS = {
+    "class": "TPV",
+    "status": 2,
+    "lat": 48.1173,
+    "lon": 11.5167,
+    "altMSL": 545.4,
+    "speed": 1.5,
+    "track": 90.0,
+}
 
-# Differential mode — from sensing.nmea.vtg docstring
-_VTG_DIFF = "$GNVTG,054.7,T,034.4,M,005.5,N,010.2,K,D*3E"
+# No fix -- no position or velocity fields
+_TPV_NO_FIX = {
+    "class": "TPV",
+    "status": 0,
+}
 
-# Autonomous mode — from sensing.nmea.vtg module
-_VTG_AUTO = "$GNVTG,054.7,T,034.4,M,005.5,N,010.2,K,A*3B"
+# SKY message with 12 used satellites and good HDOP
+_SKY_12 = {
+    "class": "SKY",
+    "uSat": 12,
+    "hdop": 0.5,
+}
 
-# An unrelated sentence type (GSA) that both parsers must silently skip
-_GSA = "$GNGSA,A,3,01,02,03,04,05,06,07,08,09,10,11,12,1.0,0.5,0.9*27"
+# SKY message where only nSat is present (older gpsd without uSat, no satellites list)
+_SKY_NSAT_ONLY = {
+    "class": "SKY",
+    "nSat": 8,
+    "hdop": 1.2,
+}
+
+# SKY without uSat but with per-satellite used flags (3 out of 4 used)
+_SKY_SATELLITES_WITH_FLAGS = {
+    "class": "SKY",
+    "nSat": 10,
+    "hdop": 0.7,
+    "satellites": [
+        {"PRN": 1, "used": True},
+        {"PRN": 2, "used": True},
+        {"PRN": 3, "used": False},
+        {"PRN": 4, "used": True},
+    ],
+}
+
+# SKY with satellites list but no per-satellite used field (fall back to nSat)
+_SKY_SATELLITES_NO_USED_FLAG = {
+    "class": "SKY",
+    "nSat": 5,
+    "hdop": 1.0,
+    "satellites": [
+        {"PRN": 1, "el": 45},
+        {"PRN": 2, "el": 30},
+    ],
+}
+
+# A gpsd WATCH echo -- should be silently ignored
+_WATCH_MSG = {"class": "WATCH", "enable": True}
+
+# A gpsd VERSION message -- should be silently ignored
+_VERSION_MSG = {"class": "VERSION", "release": "3.25"}
 
 # An obviously malformed line
-_GARBAGE = "not-nmea-at-all"
+_GARBAGE = "not-json-at-all"
 
 
 # ---------------------------------------------------------------------------
@@ -41,9 +110,9 @@ _GARBAGE = "not-nmea-at-all"
 # ---------------------------------------------------------------------------
 
 
-def _encode(lines: list[str]) -> list[bytes]:
-    """Convert sentence strings to ASCII bytes as serial.readline() returns."""
-    return [line.encode("ascii") for line in lines]
+def _line(msg: dict) -> bytes:
+    """Encode a dict as a newline-terminated JSON line."""
+    return (json.dumps(msg) + "\n").encode()
 
 
 # ---------------------------------------------------------------------------
@@ -52,21 +121,25 @@ def _encode(lines: list[str]) -> list[bytes]:
 
 
 @pytest.fixture
-def mock_hw(monkeypatch):
-    """Replace serial.Serial with a mock for the duration of a test.
+def mock_gpsd(monkeypatch):
+    """Replace socket.create_connection with a mock for the duration of a test.
 
     Returns a SimpleNamespace with attributes:
-        ser      -- the Serial instance mock
-        ser_cls  -- the Serial class mock (to verify constructor call args)
+        sock     -- the socket instance mock
+        stream   -- the stream mock returned by sock.makefile()
+        connect  -- the create_connection mock (to verify call args)
 
-    Configure ``ser.readline.side_effect`` with a list of byte strings to
-    control what the reader sees, followed by ``b""`` to simulate EOF/timeout.
+    Configure ``stream.readline.side_effect`` with a list of byte strings
+    to control what the reader sees.  A trailing ``OSError`` simulates a
+    closed connection; omit it when the test reads only a fixed number of
+    messages and will not exhaust the list.
     """
-    mock_ser = MagicMock()
-    mock_ser_cls = MagicMock(return_value=mock_ser)
-    monkeypatch.setattr(serial, "Serial", mock_ser_cls)
-
-    return SimpleNamespace(ser=mock_ser, ser_cls=mock_ser_cls)
+    mock_stream = MagicMock()
+    mock_sock = MagicMock()
+    mock_sock.makefile.return_value = mock_stream
+    mock_connect = MagicMock(return_value=mock_sock)
+    monkeypatch.setattr(socket, "create_connection", mock_connect)
+    return SimpleNamespace(sock=mock_sock, stream=mock_stream, connect=mock_connect)
 
 
 # ---------------------------------------------------------------------------
@@ -89,7 +162,7 @@ class TestGNSSData:
 
 
 # ---------------------------------------------------------------------------
-# GNSSReader — error conditions (no hardware needed)
+# GNSSReader -- error conditions (no hardware needed)
 # ---------------------------------------------------------------------------
 
 
@@ -100,143 +173,328 @@ class TestGNSSReaderErrors:
 
 
 # ---------------------------------------------------------------------------
-# GNSSReader — setup
+# GNSSReader -- connection setup
 # ---------------------------------------------------------------------------
 
 
 class TestGNSSReaderSetup:
-    def test_opens_serial_with_correct_port(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_SPS]) + [b""] * 100
-        with GNSSReader(port="/dev/ttyAMA5") as gnss:
+    def test_connects_to_default_host_and_port(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
             gnss.read()
-        mock_hw.ser_cls.assert_called_once()
-        assert mock_hw.ser_cls.call_args.args[0] == "/dev/ttyAMA5"
+        mock_gpsd.connect.assert_called_once_with(("localhost", 2947))
 
-    def test_opens_serial_with_correct_baudrate(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_SPS]) + [b""] * 100
-        with GNSSReader(baudrate=38400) as gnss:
+    def test_sends_watch_command_on_enter(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
             gnss.read()
-        assert mock_hw.ser_cls.call_args.kwargs["baudrate"] == 38400
+        mock_gpsd.sock.sendall.assert_called_once_with(
+            b'?WATCH={"enable":true,"json":true}\n'
+        )
 
-    def test_custom_port_and_baudrate_are_forwarded(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_SPS]) + [b""] * 100
-        with GNSSReader(port="/dev/ttyUSB0", baudrate=9600) as gnss:
+    def test_custom_host_and_port_are_forwarded(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader(host="192.168.1.10", port=2948) as gnss:
             gnss.read()
-        assert mock_hw.ser_cls.call_args.args[0] == "/dev/ttyUSB0"
-        assert mock_hw.ser_cls.call_args.kwargs["baudrate"] == 9600
+        mock_gpsd.connect.assert_called_once_with(("192.168.1.10", 2948))
+
+    def test_socket_timeout_is_set_on_enter(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            gnss.read()
+        mock_gpsd.sock.settimeout.assert_called_once()
+
+    def test_socket_closed_if_sendall_raises_on_enter(self, mock_gpsd):
+        mock_gpsd.sock.sendall.side_effect = OSError("refused")
+        with pytest.raises(OSError):
+            with GNSSReader():
+                pass
+        mock_gpsd.sock.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# GNSSReader — read()
+# GNSSReader - read
 # ---------------------------------------------------------------------------
 
 
 class TestGNSSReaderRead:
-    def test_returns_gnss_data_instance(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_SPS]) + [b""] * 100
+    def test_returns_gnss_data_instance(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
         with GNSSReader() as gnss:
             data = gnss.read()
         assert isinstance(data, GNSSData)
 
-    def test_vtg_is_none_before_any_vtg_received(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_SPS]) + [b""] * 100
+    def test_gga_fields_from_rtk_tpv(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_RTK)]
         with GNSSReader() as gnss:
             data = gnss.read()
-        assert data.vtg is None
-
-    def test_vtg_paired_with_preceding_vtg(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_VTG_DIFF, _GGA_SPS]) + [b""] * 100
-        with GNSSReader() as gnss:
-            data = gnss.read()
-        assert data.vtg is not None
-        assert data.vtg.mode == "D"
-
-    def test_most_recent_vtg_is_used(self, mock_hw):
-        # Two VTG sentences before one GGA: only the last VTG should be paired.
-        mock_hw.ser.readline.side_effect = _encode(
-            [_VTG_AUTO, _VTG_DIFF, _GGA_SPS]
-        ) + [b""] * 100
-        with GNSSReader() as gnss:
-            data = gnss.read()
-        assert data.vtg is not None
-        assert data.vtg.mode == "D"
-
-    def test_gga_fields_are_correctly_parsed(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_RTK]) + [b""] * 100
-        with GNSSReader() as gnss:
-            data = gnss.read()
-        assert data.gga.fix_quality == 4
+        assert data.gga.fix_quality == 4  # status 3 -> fix_quality 4
         assert data.gga.latitude_degrees == pytest.approx(48.1173, rel=1e-4)
         assert data.gga.longitude_degrees == pytest.approx(11.5167, rel=1e-4)
+        assert data.gga.altitude_meters == pytest.approx(545.4, rel=1e-4)
         assert data.gga.valid is True
 
-    def test_no_fix_gga_is_returned_with_valid_false(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_NO_FIX]) + [b""] * 100
+    def test_no_fix_tpv_gives_valid_false(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_NO_FIX)]
         with GNSSReader() as gnss:
             data = gnss.read()
         assert data.gga.valid is False
         assert data.gga.fix_quality == 0
 
-    def test_non_gga_non_vtg_lines_are_skipped(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode(
-            [_GSA, _GARBAGE, _GGA_SPS]
-        ) + [b""] * 100
+    def test_utc_time_converted_from_iso8601(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.utc_time == "123519.00"
+
+    def test_utc_time_none_when_absent_from_tpv(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_NO_FIX)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.utc_time is None
+
+    def test_altmsl_used_for_altitude(self, mock_gpsd):
+        tpv = {**_TPV_SPS, "altMSL": 100.0, "alt": 150.0}
+        mock_gpsd.stream.readline.side_effect = [_line(tpv)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.altitude_meters == pytest.approx(100.0)
+
+    def test_alt_fallback_when_altmsl_absent(self, mock_gpsd):
+        tpv = {k: v for k, v in _TPV_SPS.items() if k != "altMSL"}
+        tpv["alt"] = 150.0
+        mock_gpsd.stream.readline.side_effect = [_line(tpv)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.altitude_meters == pytest.approx(150.0)
+
+    def test_sky_fields_applied_to_subsequent_tpv(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_SKY_12), _line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.num_satellites == 12
+        assert data.gga.horizontal_dilution_of_precision == pytest.approx(0.5)
+
+    def test_sky_nsat_fallback_when_usat_absent(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_SKY_NSAT_ONLY),
+            _line(_TPV_SPS),
+        ]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.num_satellites == 8
+
+    def test_sky_satellites_used_flags_derived_when_usat_absent(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_SKY_SATELLITES_WITH_FLAGS),
+            _line(_TPV_SPS),
+        ]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.num_satellites == 3  # 3 of 4 entries have used=True
+
+    def test_sky_falls_back_to_nsat_when_no_used_flag_in_satellites(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_SKY_SATELLITES_NO_USED_FLAG),
+            _line(_TPV_SPS),
+        ]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.num_satellites == 5  # falls back to nSat
+
+    def test_sky_nsat_non_int_returns_none(self, mock_gpsd):
+        sky = {**_SKY_NSAT_ONLY, "nSat": "bad"}
+        mock_gpsd.stream.readline.side_effect = [_line(sky), _line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.num_satellites is None
+
+    def test_satellite_count_none_when_no_sky_received(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.num_satellites is None
+        assert data.gga.horizontal_dilution_of_precision is None
+
+    def test_sky_state_persists_across_tpv_messages(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_SKY_12),
+            _line(_TPV_SPS),
+            _line(_TPV_RTK),
+        ]
+        with GNSSReader() as gnss:
+            first = gnss.read()
+            second = gnss.read()
+        assert first.gga.num_satellites == 12
+        assert second.gga.num_satellites == 12
+
+    def test_vtg_speed_and_track_from_tpv(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.vtg is not None
+        assert data.vtg.speed_meters_per_second == pytest.approx(2.833, rel=1e-4)
+        assert data.vtg.track_true_degrees == pytest.approx(54.7, rel=1e-4)
+
+    def test_vtg_valid_true_when_fix_present(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.vtg is not None
+        assert data.vtg.valid is True
+
+    def test_vtg_valid_false_when_no_fix(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_NO_FIX)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.vtg is not None
+        assert data.vtg.valid is False
+        assert data.vtg.mode == "N"
+
+    def test_vtg_mode_autonomous_for_gps_fix(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.vtg is not None
+        assert data.vtg.mode == "A"
+
+    def test_vtg_mode_differential_for_dgps(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_DGPS)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.vtg is not None
+        assert data.vtg.mode == "D"
+
+    def test_vtg_mode_differential_for_rtk_fixed(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_RTK)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.vtg is not None
+        assert data.vtg.mode == "D"
+
+    def test_non_tpv_non_sky_messages_are_skipped(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_WATCH_MSG),
+            _line(_VERSION_MSG),
+            _line(_TPV_SPS),
+        ]
         with GNSSReader() as gnss:
             data = gnss.read()
         assert isinstance(data, GNSSData)
         assert data.gga.fix_quality == 1
 
-    def test_vtg_state_persists_across_multiple_reads(self, mock_hw):
-        # VTG received before first GGA, then a second GGA with no intervening VTG.
-        mock_hw.ser.readline.side_effect = _encode(
-            [_VTG_DIFF, _GGA_SPS, _GGA_RTK]
-        ) + [b""] * 100
+    def test_invalid_json_lines_are_skipped(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _GARBAGE.encode(),
+            _line(_TPV_SPS),
+        ]
         with GNSSReader() as gnss:
-            first = gnss.read()
-            second = gnss.read()
-        assert first.vtg is not None
-        assert first.vtg.mode == "D"
-        # Second read: no new VTG, so the same last_vtg is reused.
-        assert second.vtg is not None
-        assert second.vtg.mode == "D"
+            data = gnss.read()
+        assert isinstance(data, GNSSData)
+
+    def test_non_dict_json_lines_are_skipped(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            b"[1, 2, 3]\n",
+            _line(_TPV_SPS),
+        ]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert isinstance(data, GNSSData)
+
+    def test_timeout_retried_until_tpv_arrives(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            TimeoutError(),
+            _line(_TPV_SPS),
+        ]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert isinstance(data, GNSSData)
+
+    def test_os_error_raises_eof_error(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = OSError("connection reset")
+        with GNSSReader() as gnss, pytest.raises(EOFError):
+            gnss.read()
+
+    def test_empty_readline_raises_eof_error(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [b""]
+        with GNSSReader() as gnss, pytest.raises(EOFError):
+            gnss.read()
 
 
 # ---------------------------------------------------------------------------
-# GNSSReader — cleanup
+# GNSSReader - cancel
+# ---------------------------------------------------------------------------
+
+
+class TestGNSSReaderCancel:
+    def test_cancel_raises_eof_error_on_next_read(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = OSError("simulated shutdown")
+        with GNSSReader() as gnss:
+            gnss.cancel()
+            with pytest.raises(EOFError):
+                gnss.read()
+
+    def test_cancel_calls_socket_shutdown(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = OSError("simulated shutdown")
+        with GNSSReader() as gnss:
+            gnss.cancel()
+            with contextlib.suppress(EOFError):
+                gnss.read()
+        mock_gpsd.sock.shutdown.assert_called_once()
+
+    def test_cancel_during_timeout_raises_eof_error(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = TimeoutError()
+        with GNSSReader() as gnss:
+            gnss.cancel()
+            with pytest.raises(EOFError):
+                gnss.read()
+
+
+# ---------------------------------------------------------------------------
+# GNSSReader -- cleanup
 # ---------------------------------------------------------------------------
 
 
 class TestGNSSReaderCleanup:
-    def test_closes_serial_on_normal_exit(self, mock_hw):
-        mock_hw.ser.readline.side_effect = _encode([_GGA_SPS]) + [b""] * 100
+    def test_closes_stream_and_socket_on_normal_exit(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [_line(_TPV_SPS)]
         with GNSSReader() as gnss:
             gnss.read()
-        mock_hw.ser.close.assert_called_once()
+        mock_gpsd.stream.close.assert_called_once()
+        mock_gpsd.sock.close.assert_called_once()
 
-    def test_closes_serial_on_exception(self, mock_hw):
+    def test_closes_stream_and_socket_on_exception(self, mock_gpsd):
         with pytest.raises(ValueError, match="test"), GNSSReader():
             raise ValueError("test")
-        mock_hw.ser.close.assert_called_once()
+        mock_gpsd.stream.close.assert_called_once()
+        mock_gpsd.sock.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# GNSSReader — __iter__
+# GNSSReader -- __iter__
 # ---------------------------------------------------------------------------
 
 
 class TestGNSSReaderIter:
-    def test_yields_gnss_data_instances(self, mock_hw):
-        sentences = [_VTG_DIFF, _GGA_SPS, _GGA_RTK, _GGA_NO_FIX]
-        mock_hw.ser.readline.side_effect = _encode(sentences) + [b""] * 100
+    def test_yields_gnss_data_instances(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_TPV_SPS),
+            _line(_TPV_RTK),
+            _line(_TPV_NO_FIX),
+        ]
         with GNSSReader() as gnss:
             samples = list(itertools.islice(gnss, 3))
         assert len(samples) == 3
         assert all(isinstance(s, GNSSData) for s in samples)
 
-    def test_iter_yields_vtg_from_first_read(self, mock_hw):
-        sentences = [_VTG_AUTO, _GGA_SPS, _GGA_RTK]
-        mock_hw.ser.readline.side_effect = _encode(sentences) + [b""] * 100
+    def test_iter_includes_vtg_from_first_tpv(self, mock_gpsd):
+        mock_gpsd.stream.readline.side_effect = [
+            _line(_TPV_SPS),
+            _line(_TPV_RTK),
+        ]
         with GNSSReader() as gnss:
             samples = list(itertools.islice(gnss, 2))
         assert samples[0].vtg is not None
         assert samples[0].vtg.mode == "A"
+        assert samples[1].vtg is not None
+        assert samples[1].vtg.mode == "D"

--- a/uv.lock
+++ b/uv.lock
@@ -353,15 +353,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyserial"
-version = "3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -454,7 +445,6 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "gpiod" },
-    { name = "pyserial" },
     { name = "spidev" },
 ]
 
@@ -476,7 +466,6 @@ requires-dist = [
     { name = "gpiod", specifier = ">=2.4.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "pyserial", specifier = ">=3.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "spidev", specifier = ">=3.8" },


### PR DESCRIPTION
## Related Issue

Closes #56

## Context

This is a re-landing of PR #57, which was accidentally merged into `feature/39-gnss-map-visualization` instead of `main`. The code is identical — no changes from #57.

## Changes

- **`sensing/gnss/reader.py`**: Rewritten to connect to gpsd over TCP instead of opening the serial port. On enter, sends `?WATCH={"enable":true,"json":true}` and reads newline-delimited JSON. `SKY` messages update satellite count and HDOP state; `TPV` messages produce `GNSSData`. Includes `altMSL`/`alt` fallback for gpsd < 3.25, ISO 8601 → HHMMSS.ss time conversion, and `cancel()` via `socket.shutdown(SHUT_RDWR)`.
- **`tests/gnss/test_reader.py`**: Fully rewritten with 36 tests; mocks `socket.create_connection` instead of `serial.Serial`. Covers TPV/SKY field mapping, status-to-fix_quality conversion, cancellation, and cleanup.
- **`pyproject.toml`**: Removed `pyserial` dependency (replaced by stdlib `socket`).

## Type of Change

- [x] Refactor (no functional change to external interface)

## Checklist

- [x] I have performed a self-review of my code
- [x] Ruff passes
- [x] Mypy passes
- [x] All tests pass