### PR TITLE
chore: add lint and typecheck npm scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run lint && npm run typecheck"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Related Issue

Closes #61

## Context

The default `test` script generated by `npm init -y` fails unconditionally. Adding explicit `lint` and `typecheck` scripts makes the tooling more ergonomic and ensures `npm test` provides meaningful output.

## Changes

- `package.json`: added `lint` (`eslint .`), `typecheck` (`tsc --noEmit`), and updated `test` to run both

## Type of Change

- [ ] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (existing functionality will not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update

## Test Steps

1. Run `npm run lint` — should complete without errors
2. Run `npm run typecheck` — should complete without errors
3. Run `npm test` — should run both and pass

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed