### PR TITLE
chore: remove misleading "main" field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "sensing",
   "version": "1.0.0",
   "description": "See [SPECIFICATION.md](SPECIFICATION.md) for hardware wiring, OS configuration, and time synchronization setup.",
-  "main": "index.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
## Related Issue

Closes #62

## Context

The `"main": "index.js"` field was auto-generated by `npm init -y`. This project is a hardware sensing application, not a publishable library, so the field is meaningless and misleading — `index.js` does not exist.

## Changes

- `package.json`: removed the `"main"` field

## Type of Change

- [ ] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (existing functionality will not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Test Steps

1. Confirm `"main"` is absent from `package.json`
2. Run `npm run lint` and `npm run typecheck` — both should still pass

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed