### PR TITLE
refactor(gnss): introduce _GpsdMode and _GpsdStatus enums

### DIFF
--- a/sensing/gnss/reader.py
+++ b/sensing/gnss/reader.py
@@ -117,12 +117,14 @@ def _count_used_from_sky(msg: dict[str, Any]) -> int | None:
     return None
 
 
-def _parse_gpsd_status(raw: int) -> _GpsdStatus:
-    """Coerce a raw gpsd status integer to ``_GpsdStatus``.
+def _parse_gpsd_status(raw: object) -> _GpsdStatus:
+    """Coerce a raw gpsd status value to ``_GpsdStatus``.
 
-    Unknown values (not in the enum) fall back to ``NO_FIX`` so that an
-    unrecognised status from a future gpsd version degrades gracefully.
+    Non-integer values (e.g. ``null``) and unknown integers (unrecognised
+    by the enum) both fall back to ``NO_FIX`` for graceful degradation.
     """
+    if not isinstance(raw, int):
+        return _GpsdStatus.NO_FIX
     try:
         return _GpsdStatus(raw)
     except ValueError:

--- a/tests/gnss/test_reader.py
+++ b/tests/gnss/test_reader.py
@@ -623,3 +623,11 @@ class TestGNSSReaderStatusFallback:
             data = gnss.read()
         assert data.gga.fix_quality == 0
         assert data.gga.valid is False
+
+    def test_null_status_fix_quality_is_invalid(self, mock_gpsd):
+        tpv = {"class": "TPV", "status": None, "mode": 3}
+        mock_gpsd.stream.readline.side_effect = [_line(tpv)]
+        with GNSSReader() as gnss:
+            data = gnss.read()
+        assert data.gga.fix_quality == 0
+        assert data.gga.valid is False


### PR DESCRIPTION
## Related Issue

Closes #67

## Context

`sensing/gnss/reader.py` used bare integers throughout the gpsd status
and mode logic, with inline comments doing the labelling work:

```python
_STATUS_TO_FIX_QUALITY: dict[int, int] = {
    0: 0,  # No fix    -> Invalid
    1: 1,  # Normal    -> GPS fix (SPS)
    ...
}
if mode >= 2:   # what is 2?
    return 1
```

## Changes

**`sensing/gnss/reader.py`**
- Added `_GpsdMode(IntEnum)` — `UNKNOWN`, `NO_FIX`, `FIX_2D`, `FIX_3D`
- Added `_GpsdStatus(IntEnum)` — `NO_FIX`, `NORMAL`, `DGPS`, `RTK_FIXED`, `RTK_FLOAT`, `DR`
- Replaced integer keys in `_STATUS_TO_FIX_QUALITY` and `_STATUS_TO_VTG_MODE` with enum members; removed now-redundant inline comments
- Updated `_tpv_status()` to compare against `_GpsdMode.FIX_2D` and return `_GpsdStatus` members
- Added `isinstance` guard for `mode` against `null`/non-numeric values (`"mode": null` in JSON would previously raise `TypeError`)

**`tests/gnss/test_reader.py`**
- Added `test_null_mode_no_status_fix_quality_is_invalid` covering the `"mode": null` crash case

## Type of Change

- [ ] Bug fix
- [x] Refactoring (no functional change to existing behaviour, plus one defensive guard)

## Test Steps

1. `uv run --extra dev pytest tests/ -q` — all 143 tests pass
2. `uv run --extra dev ruff check sensing/gnss/reader.py` — no issues
3. `uv run --extra dev mypy sensing/gnss/reader.py` — no issues

## Checklist

- [x] Follows coding guidelines (no `else`, guard clauses, 15-line function limit)
- [x] Ruff and mypy pass with no new errors
- [x] All existing tests pass; regression test added for null-mode guard
- [x] Commit messages explain the why, not just the what