### PR TITLE
fix(server): guard heading integration against invalid deltaTime

### DIFF
--- a/server/static/yaw-compass.js
+++ b/server/static/yaw-compass.js
@@ -2,7 +2,7 @@
 
 import { drawCompassRing, drawRateArc, drawHeadingNeedle, updateReadout } from './yaw-compass-draw.js';
 
-const MAX_DELTA_TIME_SECONDS = 0.2;
+const MAX_DELTA_TIME_SECONDS = 0.5;
 
 /** @type {HTMLCanvasElement | null} */
 let _canvas = null;
@@ -45,7 +45,7 @@ export function updateYawCompass(gyroZ, timestampNanoseconds) {
     }
     const deltaTime = (timestampNanoseconds - _lastTimestampNanoseconds) / 1e9;
     _lastTimestampNanoseconds = timestampNanoseconds;
-    if (deltaTime <= 0) {
+    if (deltaTime <= 0 || deltaTime > MAX_DELTA_TIME_SECONDS) {
         _redraw(gyroZ);
         return;
     }
@@ -84,8 +84,7 @@ function _onResize() {
  * @returns {number} New integrated heading in radians.
  */
 function _integrate(currentHeading, deltaTime, gyroZ) {
-    const clampedDelta = Math.min(deltaTime, MAX_DELTA_TIME_SECONDS);
-    return (currentHeading + gyroZ * clampedDelta) % (2 * Math.PI);
+    return (currentHeading + gyroZ * deltaTime) % (2 * Math.PI);
 }
 
 /**


### PR DESCRIPTION
Closes #70

Stacked on #74.

## Summary
- Skip integration when `deltaTime <= 0` (NTP clock step backwards) or `deltaTime > 0.5 s` (dropped-sample burst)
- Keep `_lastTimestampNanoseconds` updated in both skip and integrate paths so the next sample recovers correctly
- Keep the rate arc redrawn even when integration is skipped

## Test plan
- [ ] Simulate a backward clock step (negative deltaTime): verify heading does not change
- [ ] Simulate a large gap > 0.5 s: verify heading does not jump
- [ ] Verify normal integration still works for valid deltaTime values
- [ ] Verify the rate arc continues to redraw during skipped integration frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)