### PR TITLE
fix(server): correct yaw compass direction to match physical IMU rotation

### DIFF
--- a/server/static/yaw-compass-draw.js
+++ b/server/static/yaw-compass-draw.js
@@ -62,9 +62,9 @@ export function drawHeadingNeedle(context, geometry, heading) {
 export function drawRateArc(context, geometry, gyroZ) {
     const arcLength = Math.min(Math.abs(gyroZ), Math.PI);
     const startAngle = -Math.PI / 2;
-    const endAngle = startAngle + Math.sign(gyroZ) * arcLength;
+    const endAngle = startAngle - Math.sign(gyroZ) * arcLength;
     context.beginPath();
-    context.arc(geometry.centerX, geometry.centerY, geometry.radius, startAngle, endAngle, gyroZ < 0);
+    context.arc(geometry.centerX, geometry.centerY, geometry.radius, startAngle, endAngle, gyroZ > 0);
     context.strokeStyle = _computeArcColor(Math.abs(gyroZ));
     context.lineWidth = 6;
     context.stroke();

--- a/server/static/yaw-compass.js
+++ b/server/static/yaw-compass.js
@@ -84,7 +84,7 @@ function _onResize() {
  * @returns {number} New integrated heading in radians.
  */
 function _integrate(currentHeading, deltaTime, gyroZ) {
-    return (currentHeading + gyroZ * deltaTime) % (2 * Math.PI);
+    return (currentHeading - gyroZ * deltaTime) % (2 * Math.PI);
 }
 
 /**


### PR DESCRIPTION
## Related Issue

Closes #76

## Context

The yaw compass needle and rate arc were rendered in the opposite direction to the physical IMU motion. The ISM330DHCX gyroscope uses the right-hand coordinate system (positive `gyro_z` = counter-clockwise when viewed from +Z). The HTML Canvas, however, has a flipped Y-axis — positive canvas angles render clockwise. The code passed `gyroZ` directly into the heading integrator and arc renderer without compensating for this axis flip, mirroring every visual output.

## Changes

- `server/static/yaw-compass.js` — `_integrate`: changed `+ gyroZ * deltaTime` to `- gyroZ * deltaTime` so the heading accumulates in the canvas-clockwise direction when the sensor rotates clockwise.
- `server/static/yaw-compass-draw.js` — `drawRateArc`: negated `Math.sign(gyroZ)` for the arc endpoint and inverted the `anticlockwise` flag (`gyroZ < 0` → `gyroZ > 0`) so the arc sweeps in the direction matching physical rotation.

The readout text (`compass-readout`) is intentionally unchanged — it correctly displays the raw sensor value in right-hand convention.

## Type of Change

- [x] Bug fix (fixes an issue)

## Test Steps

1. Open the Sensing dashboard in a browser connected to the live sensor server.
2. Rotate the IMU clockwise around the Z-axis (viewed from above, Z pointing up).
3. Confirm the heading needle rotates clockwise and the rate arc sweeps clockwise.
4. Rotate the IMU counter-clockwise.
5. Confirm the heading needle rotates counter-clockwise and the arc sweeps counter-clockwise.
6. Confirm the `compass-readout` text shows a positive value for counter-clockwise and negative for clockwise (right-hand convention — this is correct and unchanged).

## Screenshots (if applicable)

| Before | After |
| :----: | :---: |
| Needle and arc move opposite to physical rotation | Needle and arc match physical rotation |

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed

## Review Focus (optional)

The sign negation in `_integrate` and the inverted `anticlockwise` flag in `drawRateArc` are the two minimal changes. Please verify that the `anticlockwise` flag and arc endpoint direction are consistent (both negated together), and that the readout text is intentionally left as-is.