### PR TITLE
feature(server): display accel X/Y numeric readout alongside scatter plot

### DIFF
--- a/server/static/accel-scatter.js
+++ b/server/static/accel-scatter.js
@@ -6,6 +6,9 @@ const AXIS_RANGE_MS2 = 2;
 /** @type {HTMLCanvasElement | null} */
 let _canvas = null;
 
+/** @type {HTMLElement | null} */
+let _readoutElement = null;
+
 /** @type {Array<{x: number, y: number}>} */
 const _trailPoints = [];
 
@@ -20,6 +23,7 @@ let _pixelsPerMs2 = 0;
 export function initAccelScatter() {
     _canvas = document.getElementById('accel-canvas');
     if (_canvas == null) return;
+    _readoutElement = document.getElementById('accel-readout');
     new ResizeObserver(_onResize).observe(_canvas);
     _onResize();
 }
@@ -35,7 +39,20 @@ export function updateAccelScatter(accelX, accelY) {
     if (_trailPoints.length > MAX_TRAIL_POINTS) {
         _trailPoints.shift();
     }
+    _updateReadout(accelX, accelY);
     _redraw();
+}
+
+/**
+ * @param {number} accelX
+ * @param {number} accelY
+ * @returns {void}
+ */
+function _updateReadout(accelX, accelY) {
+    if (_readoutElement == null) return;
+    const signX = accelX >= 0 ? '+' : '';
+    const signY = accelY >= 0 ? '+' : '';
+    _readoutElement.textContent = `X ${signX}${accelX.toFixed(3)}  Y ${signY}${accelY.toFixed(3)} m/s²`;
 }
 
 /**

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -61,6 +61,14 @@
             display: block;
         }
 
+        #accel-readout {
+            text-align: center;
+            font-size: 0.9rem;
+            color: #d0d0d0;
+            padding: 4px 0;
+            flex-shrink: 0;
+        }
+
         #compass-readout {
             text-align: center;
             font-size: 0.9rem;
@@ -117,6 +125,7 @@
         <div class="imu-sub-panel">
             <div class="panel-title">Accel X-Y</div>
             <canvas id="accel-canvas" class="imu-canvas"></canvas>
+            <div id="accel-readout">X +0.000  Y +0.000 m/s²</div>
         </div>
         <div class="imu-sub-panel">
             <div class="panel-title">Yaw Rate</div>


### PR DESCRIPTION
## Related Issue

Closes #78

## Context

The Accel X-Y panel showed only a scatter plot, giving no way to read exact instantaneous values. The yaw rate panel already has a text readout (`#compass-readout`); this PR adds an equivalent for acceleration, following the same established pattern.

## Changes

- `server/static/index.html` — added `#accel-readout` div below the accel canvas; added CSS styled identically to `#compass-readout`.
- `server/static/accel-scatter.js` — wired up `_readoutElement` in `initAccelScatter`; added `_updateReadout` helper called on every sample from `updateAccelScatter`.

## Type of Change

- [x] New feature (adds functionality)

## Test Steps

1. Start the Sensing server and open the dashboard.
2. Observe the Accel X-Y panel — a readout line should appear below the canvas showing `X +0.000  Y +0.000 m/s²` initially.
3. Move the IMU along the X-axis — confirm the X value changes and has the correct sign.
4. Move the IMU along the Y-axis — confirm the Y value changes and has the correct sign.
5. Confirm the readout updates in real time at the sensor rate.
6. Confirm styling matches the yaw rate readout (same font, size, and colour).

## Screenshots (if applicable)

| Before | After |
| :----: | :---: |
| Scatter plot only, no numeric values | Scatter plot with `X +0.123  Y -0.456 m/s²` readout below |

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed

## Review Focus (optional)

The `_updateReadout` helper in `accel-scatter.js` and the corresponding HTML/CSS additions are the only changes. Please verify the sign formatting logic matches the compass readout convention.