### PR TITLE
ci(gh-actions): update Gemini review workflow permissions and event triggers

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -2,6 +2,8 @@ name: Gemini Code Review
 
 on:
   pull_request:
+    # It's best practice to trigger on these specific PR events
+    types: [opened, synchronize, reopened]
     branches: [main]
 
 jobs:
@@ -9,14 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # Crucial: Allows Gemini to post the comment
+      issues: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Run Gemini PR Review
         uses: google-github-actions/run-gemini-cli@v0
+        env:
+          # The CLI needs the GitHub token to read the PR and post the review
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          gemini_model: gemini-2.5-flash
-          prompt: "Please review the code changes in this pull request and provide constructive feedback."
+          # gemini_model: gemini-2.5-flash (Optional: The CLI usually defaults to an optimal model, but you can specify it if you prefer)


### PR DESCRIPTION
## Related Issue

Closes #90

## Context

The initial Gemini code review workflow (#87) had three gaps that caused the action to fail or produce incomplete output:

1. **Missing `issues: write` permission** — GitHub's backend treats every PR as an Issue. The action posts line-level review comments via `pull-requests: write`, but posts the high-level summary to the PR conversation thread via the Issues API. Without `issues: write`, the summary never appears.
2. **Missing `GITHUB_TOKEN` env var** — `run-gemini-cli` needs this in its environment to read the PR diff and authenticate when posting comments.
3. **No PR event `types` filter** — Without it, the workflow triggers on every PR event (label changes, assignments, review requests), not just the relevant ones.

Additionally, the hardcoded `gemini_model` and `prompt` overrides were removed so the action uses the optimised defaults from the `run-gemini-cli` maintainers. The model name is left as a commented-out hint.

## Changes

- Add `issues: write` to workflow permissions
- Expose `GITHUB_TOKEN` as an env var on the action step
- Add `types: [opened, synchronize, reopened]` to the PR trigger
- Remove hardcoded `gemini_model` and `prompt`; leave model as a comment

## Type of Change

- [x] CI/CD configuration change (no production code affected)

## Test Steps

1. Open a new PR against `main` (or push a commit to an existing PR)
2. Verify the `Gemini Code Review` workflow run completes without errors
3. Confirm a summary comment appears in the PR conversation thread
4. Confirm line-level review comments appear on the diff (if Gemini flagged anything)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Change is limited to a single concern
- [x] Related issue linked with `Closes #90`

🤖 Generated with [Claude Code](https://claude.com/claude-code)