### PR TITLE
feature(server): integrate NTRIPClient into server lifespan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ node_modules/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local runtime config (contains credentials)
+config.toml

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,8 @@
+[ntrip]
+host = "ntrip.example.com"
+port = 2101
+mountpoint = "NEAR00"
+serial_device = "/dev/ttyAMA5"
+username = ""
+password = ""
+gga_interval_seconds = 10.0

--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,41 @@
+"""NTRIP configuration loader from a TOML file."""
+
+import tomllib
+from pathlib import Path
+
+from sensing.ntrip.config import NTRIPConfig
+
+__all__ = ["load_ntrip_config"]
+
+_CONFIG_PATH = Path("config.toml")
+
+
+def load_ntrip_config() -> NTRIPConfig | None:
+    """Load NTRIP configuration from ``config.toml``.
+
+    Returns ``None`` if the file is absent or has no ``[ntrip]`` section.
+    Missing required fields raise ``KeyError`` at startup so the operator
+    is alerted immediately rather than failing silently at runtime.
+
+    Returns:
+        ``NTRIPConfig`` from the ``[ntrip]`` section, or ``None``.
+
+    Raises:
+        KeyError: If a required field is absent from the ``[ntrip]`` section.
+    """
+    if not _CONFIG_PATH.exists():
+        return None
+    with _CONFIG_PATH.open("rb") as f:
+        data = tomllib.load(f)
+    section = data.get("ntrip")
+    if section is None:
+        return None
+    return NTRIPConfig(
+        host=section["host"],
+        port=section["port"],
+        mountpoint=section["mountpoint"],
+        serial_device=section["serial_device"],
+        username=section.get("username", ""),
+        password=section.get("password", ""),
+        gga_interval_seconds=section.get("gga_interval_seconds", 10.0),
+    )

--- a/server/main.py
+++ b/server/main.py
@@ -13,7 +13,7 @@ one ``type="imu"`` message every fifth IMU sample (~20 Hz).
 import asyncio
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
+from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
 from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -21,7 +21,10 @@ from fastapi.staticfiles import StaticFiles
 
 from sensing.gnss import GNSSReader
 from sensing.imu import IMUReader
+from sensing.nmea.types import GGAData
+from sensing.ntrip import NTRIPClient, NTRIPConfig
 from server.broadcaster import add_subscriber, remove_subscriber
+from server.config import load_ntrip_config
 from server.sensors import run_gnss_loop, run_imu_loop
 
 __all__ = ["app"]
@@ -30,21 +33,33 @@ _STATIC_DIRECTORY = Path(__file__).parent / "static"
 _QUEUE_MAXIMUM_SIZE = 10
 _TIMEOUT_SECONDS = 5.0
 
+
+def _ntrip_context(
+    cfg: NTRIPConfig | None,
+    gga_slot: list[GGAData | None],
+) -> AbstractContextManager[NTRIPClient | None]:
+    if cfg is None:
+        return nullcontext()
+    return NTRIPClient(cfg, lambda: gga_slot[0])
+
+
 @asynccontextmanager
 async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    gga_slot: list[GGAData | None] = [None]
+    ntrip_cfg = load_ntrip_config()
     loop = asyncio.get_running_loop()
     with (
-        ThreadPoolExecutor(max_workers=2) as executor,
+        ThreadPoolExecutor(max_workers=3) as executor,
         GNSSReader() as gnss,
         IMUReader() as imu,
+        _ntrip_context(ntrip_cfg, gga_slot) as ntrip,
     ):
-        loop.run_in_executor(executor, run_gnss_loop, loop, gnss)
+        loop.run_in_executor(executor, run_gnss_loop, loop, gnss, gga_slot)
         loop.run_in_executor(executor, run_imu_loop, loop, imu)
-
+        if ntrip is not None:
+            loop.run_in_executor(executor, ntrip.stream)
         yield
-
-        # Safely interrupt blocking I/O calls first; the executor context
-        # manager calls shutdown(wait=True) when its block exits.
+        # Interrupt blocking I/O first; executor shutdown(wait=True) follows.
         gnss.cancel()
         imu.cancel()
 

--- a/server/main.py
+++ b/server/main.py
@@ -11,7 +11,7 @@ one ``type="imu"`` message every fifth IMU sample (~20 Hz).
 """
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
 from pathlib import Path
@@ -25,7 +25,7 @@ from sensing.nmea.types import GGAData
 from sensing.ntrip import NTRIPClient, NTRIPConfig
 from server.broadcaster import add_subscriber, remove_subscriber
 from server.config import load_ntrip_config
-from server.sensors import run_gnss_loop, run_imu_loop
+from server.sensors import LatestGGA, run_gnss_loop, run_imu_loop
 
 __all__ = ["app"]
 
@@ -36,25 +36,25 @@ _TIMEOUT_SECONDS = 5.0
 
 def _ntrip_context(
     cfg: NTRIPConfig | None,
-    gga_slot: list[GGAData | None],
+    gga_provider: Callable[[], GGAData | None],
 ) -> AbstractContextManager[NTRIPClient | None]:
     if cfg is None:
         return nullcontext()
-    return NTRIPClient(cfg, lambda: gga_slot[0])
+    return NTRIPClient(cfg, gga_provider)
 
 
 @asynccontextmanager
 async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    gga_slot: list[GGAData | None] = [None]
+    latest_gga = LatestGGA()
     ntrip_cfg = load_ntrip_config()
     loop = asyncio.get_running_loop()
     with (
         ThreadPoolExecutor(max_workers=3) as executor,
         GNSSReader() as gnss,
         IMUReader() as imu,
-        _ntrip_context(ntrip_cfg, gga_slot) as ntrip,
+        _ntrip_context(ntrip_cfg, latest_gga) as ntrip,
     ):
-        loop.run_in_executor(executor, run_gnss_loop, loop, gnss, gga_slot)
+        loop.run_in_executor(executor, run_gnss_loop, loop, gnss, latest_gga.update)
         loop.run_in_executor(executor, run_imu_loop, loop, imu)
         if ntrip is not None:
             loop.run_in_executor(executor, ntrip.stream)

--- a/server/sensors.py
+++ b/server/sensors.py
@@ -4,6 +4,7 @@ import asyncio
 
 from sensing.gnss import GNSSReader
 from sensing.imu import IMUData, IMUReader
+from sensing.nmea.types import GGAData
 from server.broadcaster import broadcast_message
 from server.formatters import format_gnss_message, format_imu_message
 
@@ -12,7 +13,11 @@ __all__ = ["run_gnss_loop", "run_imu_loop"]
 _IMU_DECIMATION = 5
 
 
-def run_gnss_loop(loop: asyncio.AbstractEventLoop, gnss: GNSSReader) -> None:
+def run_gnss_loop(
+    loop: asyncio.AbstractEventLoop,
+    gnss: GNSSReader,
+    gga_slot: list[GGAData | None] | None = None,
+) -> None:
     """Read GNSS data continuously and broadcast it to the event loop.
 
     The caller owns *gnss* and must use it as an open context manager. The
@@ -22,9 +27,13 @@ def run_gnss_loop(loop: asyncio.AbstractEventLoop, gnss: GNSSReader) -> None:
     Args:
         loop: Running asyncio event loop to broadcast messages on.
         gnss: An open ``GNSSReader`` instance managed by the caller.
+        gga_slot: Optional single-element list updated each iteration with
+            the latest ``GGAData`` for NTRIP position feedback.
     """
     try:
         for data in gnss:
+            if gga_slot is not None:
+                gga_slot[0] = data.gga
             message = format_gnss_message(data)
             broadcast_message(message, loop)
     except EOFError:

--- a/server/sensors.py
+++ b/server/sensors.py
@@ -1,6 +1,7 @@
 """Background sensor reading loops."""
 
 import asyncio
+from collections.abc import Callable
 
 from sensing.gnss import GNSSReader
 from sensing.imu import IMUData, IMUReader
@@ -8,15 +9,36 @@ from sensing.nmea.types import GGAData
 from server.broadcaster import broadcast_message
 from server.formatters import format_gnss_message, format_imu_message
 
-__all__ = ["run_gnss_loop", "run_imu_loop"]
+__all__ = ["LatestGGA", "run_gnss_loop", "run_imu_loop"]
 
 _IMU_DECIMATION = 5
+
+
+class LatestGGA:
+    """Cache of the most recent GGAData from the GNSS loop.
+
+    Used as the ``gga_provider`` callable passed to ``NTRIPClient``.
+    The GNSS loop calls ``update`` each iteration; the NTRIP thread
+    calls the instance to read the cached value.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with no position."""
+        self._gga: GGAData | None = None
+
+    def update(self, gga: GGAData) -> None:
+        """Store the most recent GGA reading."""
+        self._gga = gga
+
+    def __call__(self) -> GGAData | None:
+        """Return the most recent GGA reading, or ``None`` if not yet received."""
+        return self._gga
 
 
 def run_gnss_loop(
     loop: asyncio.AbstractEventLoop,
     gnss: GNSSReader,
-    gga_slot: list[GGAData | None] | None = None,
+    on_gga: Callable[[GGAData], None] | None = None,
 ) -> None:
     """Read GNSS data continuously and broadcast it to the event loop.
 
@@ -27,13 +49,13 @@ def run_gnss_loop(
     Args:
         loop: Running asyncio event loop to broadcast messages on.
         gnss: An open ``GNSSReader`` instance managed by the caller.
-        gga_slot: Optional single-element list updated each iteration with
-            the latest ``GGAData`` for NTRIP position feedback.
+        on_gga: Optional callback invoked with each new ``GGAData``
+            (e.g. ``LatestGGA.update``) for NTRIP position feedback.
     """
     try:
         for data in gnss:
-            if gga_slot is not None:
-                gga_slot[0] = data.gga
+            if on_gga is not None:
+                on_gga(data.gga)
             message = format_gnss_message(data)
             broadcast_message(message, loop)
     except EOFError:

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -68,6 +68,7 @@ def mock_hardware_readers() -> (
     with (
         patch("server.main.GNSSReader", return_value=gnss_controller),
         patch("server.main.IMUReader", return_value=imu_controller),
+        patch("server.main.load_ntrip_config", return_value=None),
     ):
         yield gnss_controller, imu_controller
 

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -1,0 +1,51 @@
+"""Tests for server.config.load_ntrip_config."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sensing.ntrip.config import NTRIPConfig
+from server.config import load_ntrip_config
+
+
+def test_file_absent_returns_none(tmp_path: Path) -> None:
+    with patch("server.config._CONFIG_PATH", tmp_path / "config.toml"):
+        assert load_ntrip_config() is None
+
+
+def test_no_ntrip_section_returns_none(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text("[other]\nkey = 'value'\n")
+    with patch("server.config._CONFIG_PATH", config):
+        assert load_ntrip_config() is None
+
+
+def test_valid_section_returns_config(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "[ntrip]\n"
+        'host = "ntrip.example.com"\n'
+        "port = 2101\n"
+        'mountpoint = "NEAR00"\n'
+        'serial_device = "/dev/ttyAMA5"\n'
+    )
+    with patch("server.config._CONFIG_PATH", config):
+        result = load_ntrip_config()
+    assert result == NTRIPConfig(
+        host="ntrip.example.com",
+        port=2101,
+        mountpoint="NEAR00",
+        serial_device="/dev/ttyAMA5",
+    )
+
+
+def test_missing_required_field_raises_key_error(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "[ntrip]\n"
+        'host = "ntrip.example.com"\n'
+        "port = 2101\n"
+    )
+    with patch("server.config._CONFIG_PATH", config), pytest.raises(KeyError):
+        load_ntrip_config()


### PR DESCRIPTION
Closes #92

## Summary

- Add `server/config.py` with `load_ntrip_config()` — reads `config.toml` via `tomllib`, returns `None` if the file is absent or has no `[ntrip]` section, raises `KeyError` on missing required fields so misconfiguration is caught at startup
- Add `config.toml.example` as a template; add `config.toml` to `.gitignore` to keep credentials out of VCS
- Add `gga_slot` parameter to `run_gnss_loop` — a single-element list written each GNSS iteration so the NTRIP client always has the latest rover position (GIL-safe, no explicit lock needed)
- Update `server/main.py` lifespan: new `_ntrip_context` helper returns `nullcontext()` when no config is present, or `NTRIPClient(cfg, lambda: gga_slot[0])` otherwise; NTRIP thread is joined automatically via context manager exit order
- Patch `load_ntrip_config` to `None` in `tests/server/conftest.py` so existing tests run without a `config.toml`
- Add `tests/server/test_config.py` covering: file absent, missing `[ntrip]` section, valid config, missing required field

## Test plan

- [ ] `uv run --extra dev pytest tests/ -q` — all 186 tests pass
- [ ] `uv run --extra dev ruff check server/ tests/server/` — no issues
- [ ] `uv run --extra dev mypy server/ tests/server/` — no issues
- [ ] Copy `config.toml.example` → `config.toml`, fill in real caster credentials, run the server and confirm `fix_quality` converges to 4 (RTK Fixed) in the WebSocket stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)