### PR TITLE
style(dashboard): widen IMU panel to 50% for iPad display

### DIFF
--- a/server/static/index.html
+++ b/server/static/index.html
@@ -17,7 +17,7 @@
 
         #layout {
             display: grid;
-            grid-template-columns: 1fr 320px;
+            grid-template-columns: 1fr 1fr;
             grid-template-rows: 1fr auto;
             height: 100vh;
         }


### PR DESCRIPTION
## Summary

- Change `grid-template-columns` from `1fr 480px` to `1fr 1fr`, giving the IMU panel 50% of the viewport width
- Makes the accel scatter plot and yaw compass noticeably larger on iPad-sized screens
- Fully responsive — adapts to any screen width

## Test plan

- [ ] Open the dashboard on an iPad or browser at ~768–1024px width in landscape
- [ ] Confirm the IMU panel (right side) occupies half the screen
- [ ] Confirm the accel scatter and yaw compass canvases are larger than before
- [ ] Confirm the map (left side) still renders correctly

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)