### PR TITLE
fix(accel-scatter): widen axis range to ±10 m/s² and derive ticks automatically

### DIFF
--- a/server/static/accel-scatter.js
+++ b/server/static/accel-scatter.js
@@ -1,7 +1,7 @@
 /* Acceleration X-Y scatter panel — 100-point fading trail on a Canvas element. */
 
 const MAX_TRAIL_POINTS = 100;
-const AXIS_RANGE_MS2 = 2;
+const AXIS_RANGE_MS2 = 10;
 
 /** @type {HTMLCanvasElement | null} */
 let _canvas = null;
@@ -116,7 +116,8 @@ function _drawAxes(context) {
  * @returns {void}
  */
 function _drawScale(context) {
-    const ticks = [-2, -1, 1, 2];
+    const half = AXIS_RANGE_MS2 / 2;
+    const ticks = [-AXIS_RANGE_MS2, -half, half, AXIS_RANGE_MS2];
     context.strokeStyle = '#333';
     context.lineWidth = 1;
     for (const tick of ticks) {


### PR DESCRIPTION
## Summary

- Increase `AXIS_RANGE_MS2` from `2` to `10` — covers just over 1G (~9.81 m/s²), suitable for cycling/driving
- Derive tick positions automatically as `[-range, -range/2, range/2, range]` so adjusting the range requires changing only the one constant

## Test plan

- [ ] Open the dashboard and verify the accel scatter axes show ±10 m/s² range
- [ ] Confirm tick marks appear at ±5 and ±10
- [ ] Verify that ~1G accelerations are plotted within the visible area

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)