### PR TITLE
feature(gnss): keep map pin centered and pan map on position updates

### DIFF
--- a/server/static/gnss.js
+++ b/server/static/gnss.js
@@ -76,10 +76,9 @@ function _buildPopupNode(label, numSatellites, hdop) {
 }
 
 function _positionMarker(latlng, popupNode) {
-    if (!centeredOnFix) {
-        map.setView(latlng, 17);
-        centeredOnFix = true;
-    }
+    const zoom = centeredOnFix ? map.getZoom() : 17;
+    centeredOnFix = true;
+    map.setView(latlng, zoom);
     if (marker === null) {
         marker = L.marker(latlng).addTo(map).bindPopup(popupNode);
         return;


### PR DESCRIPTION
## Related Issue

Closes #104

## Context

The map was centered only on the first GNSS fix; after that only the Leaflet marker moved. As the vehicle traveled, the pin drifted toward the edge of the viewport and eventually off-screen. For a live tracking dashboard the expected behavior is for the map to follow the position, keeping the pin visually centered at all times.

## Changes

- `server/static/gnss.js` — in `_positionMarker`, call `map.setView(latlng, zoom)` on every fix instead of only the first; zoom 17 is used on first fix, current zoom is preserved thereafter

## Type of Change

- [x] New feature (adds functionality)

## Test Steps

1. Start the dashboard with a live GNSS source
2. Observe that on the first fix the map zooms to level 17 and centers on the position
3. As the position updates, confirm the map pans to keep the pin at the center of the viewport
4. Manually zoom in/out and confirm the zoom level is preserved across subsequent pans

## Screenshots (if applicable)

| Before | After |
| :----: | :---: |
| Pin moves around a static map | Map pans, pin stays centered |

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed

> **Note on automated tests:** The project has no front-end test harness. `npm test` runs only ESLint and TypeScript type-checking. The changed code (`_positionMarker`) is tightly coupled to the Leaflet map API and DOM, making unit tests impractical without a dedicated framework (e.g., Vitest + jsdom + Leaflet mocks). This change is verified by the manual test steps above.

## Review Focus (optional)

The change is a 3-line diff in `_positionMarker` in `gnss.js:78` — the only substantive change is moving `map.setView()` outside the first-fix guard.