### PR TITLE
fix(yaw-compass): remove heading needle and integration logic

### DIFF
--- a/server/static/app.js
+++ b/server/static/app.js
@@ -6,7 +6,7 @@ import { initYawCompass, updateYawCompass } from './yaw-compass.js';
 
 function _handleImu(message) {
     updateAccelScatter(message.accel_x, message.accel_y);
-    updateYawCompass(message.gyro_z, message.timestamp_ns);
+    updateYawCompass(message.gyro_z);
 }
 
 function _dispatchMessage(message) {

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -77,20 +77,6 @@
             flex-shrink: 0;
         }
 
-        #reset-heading-button {
-            background: #333;
-            color: #aaa;
-            border: 1px solid #444;
-            border-radius: 3px;
-            padding: 3px 8px;
-            cursor: pointer;
-            font-family: inherit;
-            font-size: 0.75rem;
-            align-self: center;
-            flex-shrink: 0;
-            margin-bottom: 4px;
-        }
-
         #status-bar {
             grid-column: 1 / -1;
             background: #1e1e1e;
@@ -131,7 +117,6 @@
             <div class="panel-title">Yaw Rate</div>
             <canvas id="compass-canvas" class="imu-canvas"></canvas>
             <div id="compass-readout">+0.0 °/s</div>
-            <button id="reset-heading-button">Reset heading</button>
         </div>
     </div>
     <div id="status-bar" class="stale">

--- a/server/static/yaw-compass-draw.js
+++ b/server/static/yaw-compass-draw.js
@@ -34,25 +34,6 @@ export function drawCompassRing(context, geometry) {
 }
 
 /**
- * Draws the heading needle at the given integrated heading angle.
- * @param {CanvasRenderingContext2D} context
- * @param {CompassGeometry} geometry
- * @param {number} heading - Integrated heading angle in radians.
- * @returns {void}
- */
-export function drawHeadingNeedle(context, geometry, heading) {
-    const needleAngle = heading - Math.PI / 2;
-    const tipX = geometry.centerX + geometry.radius * 0.8 * Math.cos(needleAngle);
-    const tipY = geometry.centerY + geometry.radius * 0.8 * Math.sin(needleAngle);
-    context.beginPath();
-    context.moveTo(geometry.centerX, geometry.centerY);
-    context.lineTo(tipX, tipY);
-    context.strokeStyle = '#d0d0d0';
-    context.lineWidth = 2;
-    context.stroke();
-}
-
-/**
  * Draws a colored arc indicating the current yaw rate magnitude and direction.
  * @param {CanvasRenderingContext2D} context
  * @param {CompassGeometry} geometry

--- a/server/static/yaw-compass.js
+++ b/server/static/yaw-compass.js
@@ -1,8 +1,6 @@
-/* Yaw rate compass — integrated heading needle and instantaneous rate arc. */
+/* Yaw rate compass — instantaneous rate arc. */
 
-import { drawCompassRing, drawRateArc, drawHeadingNeedle, updateReadout } from './yaw-compass-draw.js';
-
-const MAX_DELTA_TIME_SECONDS = 0.5;
+import { drawCompassRing, drawRateArc, updateReadout } from './yaw-compass-draw.js';
 
 /** @type {HTMLCanvasElement | null} */
 let _canvas = null;
@@ -10,56 +8,25 @@ let _canvas = null;
 /** @type {HTMLElement | null} */
 let _readoutElement = null;
 
-let _integratedHeading = 0;
-
-/** @type {number | null} */
-let _lastTimestampNanoseconds = null;
-
 /**
- * Initialises the yaw compass panel, wiring up the canvas and reset button.
+ * Initialises the yaw compass panel, wiring up the canvas.
  * @returns {void}
  */
 export function initYawCompass() {
     _canvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById('compass-canvas'));
     if (_canvas == null) return;
     _readoutElement = document.getElementById('compass-readout');
-    const resetButton = document.getElementById('reset-heading-button');
-    if (resetButton != null) {
-        resetButton.addEventListener('click', _resetHeading);
-    }
     new ResizeObserver(_onResize).observe(_canvas);
     _onResize();
 }
 
 /**
- * Integrates gyroZ over the elapsed time and redraws the compass.
+ * Redraws the compass with the current gyroZ value.
  * @param {number} gyroZ - Angular rate around the Z axis in rad/s.
- * @param {number} timestampNanoseconds - Sample timestamp in nanoseconds.
  * @returns {void}
  */
-export function updateYawCompass(gyroZ, timestampNanoseconds) {
-    if (_lastTimestampNanoseconds == null) {
-        _lastTimestampNanoseconds = timestampNanoseconds;
-        _redraw(gyroZ);
-        return;
-    }
-    const deltaTime = (timestampNanoseconds - _lastTimestampNanoseconds) / 1e9;
-    _lastTimestampNanoseconds = timestampNanoseconds;
-    if (deltaTime <= 0 || deltaTime > MAX_DELTA_TIME_SECONDS) {
-        _redraw(gyroZ);
-        return;
-    }
-    _integratedHeading = _integrate(_integratedHeading, deltaTime, gyroZ);
+export function updateYawCompass(gyroZ) {
     _redraw(gyroZ);
-}
-
-/**
- * @returns {void}
- */
-function _resetHeading() {
-    _integratedHeading = 0;
-    _lastTimestampNanoseconds = /** @type {number | null} */ (null);
-    _redraw(0);
 }
 
 /**
@@ -75,16 +42,6 @@ function _onResize() {
         context.scale(ratio, ratio);
     }
     _redraw(0);
-}
-
-/**
- * @param {number} currentHeading - Current integrated heading in radians.
- * @param {number} deltaTime - Elapsed time in seconds.
- * @param {number} gyroZ - Angular rate around the Z axis in rad/s.
- * @returns {number} New integrated heading in radians.
- */
-function _integrate(currentHeading, deltaTime, gyroZ) {
-    return (currentHeading - gyroZ * deltaTime) % (2 * Math.PI);
 }
 
 /**
@@ -111,6 +68,5 @@ function _redraw(gyroZ) {
     context.clearRect(0, 0, _canvas.clientWidth, _canvas.clientHeight);
     drawCompassRing(context, geometry);
     drawRateArc(context, geometry, gyroZ);
-    drawHeadingNeedle(context, geometry, _integratedHeading);
     updateReadout(_readoutElement, gyroZ);
 }


### PR DESCRIPTION
## Related Issue

Closes #106

## Context

The compass showed a white needle driven by gyro Z integration over time. Integrated heading drifts without a correction source (e.g. magnetometer or GNSS course), making the needle misleading rather than informative.

## Changes

- Removed `drawHeadingNeedle` from `yaw-compass-draw.js`
- Removed heading integration state (`_integratedHeading`, `_lastTimestampNanoseconds`, `_integrate`, `MAX_DELTA_TIME_SECONDS`) from `yaw-compass.js`
- Removed reset button wiring from `initYawCompass` and simplified `updateYawCompass` (dropped unused `timestampNanoseconds` param)
- Removed "Reset heading" button and its CSS from `index.html`

## Type of Change

- [x] Bug fix / removal of misleading UI element

## Test Steps

1. Start the server and open the dashboard
2. Verify the yaw compass shows only the colored rate arc — no white needle
3. Verify the "Reset heading" button is gone
4. Verify the readout still shows the current yaw rate in °/s

## Checklist

- [x] Code follows the project style guidelines
- [x] No new files created unnecessarily
- [x] No dead code left behind